### PR TITLE
Add WAV transcription script

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,19 @@
 TEST
 WWW
 AAA
+
+## Transcribing WAV files
+
+This repository includes a sample script `transcribe.py` that uses the `speech_recognition` package to convert a WAV audio file to text. Install the dependency first:
+
+```bash
+pip install SpeechRecognition
+```
+
+Then run:
+
+```bash
+python transcribe.py path/to/your_audio.wav
+```
+
+The script prints the recognized Japanese text to standard output.

--- a/transcribe.py
+++ b/transcribe.py
@@ -1,0 +1,22 @@
+import sys
+import speech_recognition as sr
+
+
+def transcribe_wav(filename):
+    r = sr.Recognizer()
+    with sr.AudioFile(filename) as source:
+        audio = r.record(source)
+    try:
+        text = r.recognize_google(audio, language='ja-JP')
+        print(text)
+    except sr.UnknownValueError:
+        print('Could not understand audio')
+    except sr.RequestError as e:
+        print(f'Could not request results: {e}')
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        print('Usage: python transcribe.py path/to/audio.wav')
+        sys.exit(1)
+    transcribe_wav(sys.argv[1])


### PR DESCRIPTION
## Summary
- add `transcribe.py` for simple speech-to-text using `speech_recognition`
- document how to use it in the README

## Testing
- `python3 -c "import speech_recognition"` *(fails: ModuleNotFoundError)*